### PR TITLE
Cfg flag improvements

### DIFF
--- a/popsicle/Cargo.toml
+++ b/popsicle/Cargo.toml
@@ -21,9 +21,11 @@ ocelot         = { path = "../ocelot" }
 scuttlebutt    = { path = "../scuttlebutt" }
 itertools      = "0.8"
 rand           = "0.7"
-openssl        = "0.10"
 sha2           = "0.8"
 fancy-garbling = { path = "../fancy-garbling", optional = true }
+
+[target.'cfg(feature = "psty")'.dependencies]
+openssl        = "0.10"
 
 [dev-dependencies]
 criterion  = "0.2.11"

--- a/popsicle/Cargo.toml
+++ b/popsicle/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 
 [features]
 nightly = ["rand/nightly", "scuttlebutt/nightly", "ocelot/nightly", "ocelot/nightly"]
-psty = ["fancy-garbling"]
+psty = ["fancy-garbling", "openssl"]
 
 [dependencies]
 ocelot         = { path = "../ocelot" }
@@ -23,9 +23,7 @@ itertools      = "0.8"
 rand           = "0.7"
 sha2           = "0.8"
 fancy-garbling = { path = "../fancy-garbling", optional = true }
-
-[target.'cfg(feature = "psty")'.dependencies]
-openssl        = "0.10"
+openssl        = { version = "0.10", optional = true }
 
 [dev-dependencies]
 criterion  = "0.2.11"

--- a/popsicle/src/errors.rs
+++ b/popsicle/src/errors.rs
@@ -29,12 +29,14 @@ pub enum Error {
     /// Not enough payloads.
     InvalidPayloadsLength,
     /// SSL Error
-    SSLError(openssl::error::ErrorStack),
     #[cfg(feature = "psty")]
+    SSLError(openssl::error::ErrorStack),
     /// An error occurred in the underlying 2PC protocol.
+    #[cfg(feature = "psty")]
     TwopcError(fancy_garbling::errors::TwopacError),
 }
 
+#[cfg(feature = "psty")]
 impl From<openssl::error::ErrorStack> for Error {
     #[inline]
     fn from(e: openssl::error::ErrorStack) -> Error {
@@ -88,6 +90,7 @@ impl std::fmt::Display for Error {
             ),
             Error::PsiProtocolError(s) => write!(f, "PSI protocol error: {}", s),
             Error::InvalidPayloadsLength => write!(f, "Invalid length of payloads!"),
+            #[cfg(feature = "psty")]
             Error::SSLError(e) => write!(f, "SSL Error: {}", e),
             #[cfg(feature = "psty")]
             Error::TwopcError(e) => write!(f, "2PC protocol error: {}", e),

--- a/scuttlebutt/Cargo.toml
+++ b/scuttlebutt/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 nightly = ["curve25519-dalek/avx2_backend", "rand/nightly"]
 unstable = []
 serde1 = ["serde"]
+unix = []
 
 [dependencies]
 curve25519-dalek = { version = "2", features = ["std"], optional = true }

--- a/scuttlebutt/Cargo.toml
+++ b/scuttlebutt/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 nightly = ["curve25519-dalek/avx2_backend", "rand/nightly"]
 unstable = []
 serde1 = ["serde"]
-unix = []
 
 [dependencies]
 curve25519-dalek = { version = "2", features = ["std"], optional = true }

--- a/scuttlebutt/src/channel.rs
+++ b/scuttlebutt/src/channel.rs
@@ -7,14 +7,14 @@
 mod hash_channel;
 mod sync_channel;
 mod track_channel;
-#[cfg(feature = "unix")]
+#[cfg(unix)]
 mod unix_channel;
 
 pub use hash_channel::HashChannel;
 pub use sync_channel::SyncChannel;
 pub use track_channel::TrackChannel;
 
-#[cfg(feature = "unix")]
+#[cfg(unix)]
 pub use unix_channel::{track_unix_channel_pair, unix_channel_pair, TrackUnixChannel, UnixChannel};
 
 use crate::{Block, Block512};

--- a/scuttlebutt/src/channel.rs
+++ b/scuttlebutt/src/channel.rs
@@ -7,11 +7,14 @@
 mod hash_channel;
 mod sync_channel;
 mod track_channel;
+#[cfg(feature = "unix")]
 mod unix_channel;
 
 pub use hash_channel::HashChannel;
 pub use sync_channel::SyncChannel;
 pub use track_channel::TrackChannel;
+
+#[cfg(feature = "unix")]
 pub use unix_channel::{track_unix_channel_pair, unix_channel_pair, TrackUnixChannel, UnixChannel};
 
 use crate::{Block, Block512};

--- a/scuttlebutt/src/lib.rs
+++ b/scuttlebutt/src/lib.rs
@@ -33,18 +33,24 @@ pub use crate::{
     block::Block,
     block512::Block512,
     channel::{
-        track_unix_channel_pair,
-        unix_channel_pair,
         AbstractChannel,
         Channel,
         HashChannel,
         SyncChannel,
-        TrackChannel,
-        TrackUnixChannel,
-        UnixChannel,
+        TrackChannel
     },
     hash_aes::{AesHash, AES_HASH},
     rand_aes::AesRng,
+};
+
+#[cfg(feature = "unix")]
+pub use crate::{
+    channel::{
+        UnixChannel,
+        TrackUnixChannel,
+        track_unix_channel_pair,
+        unix_channel_pair,
+    }
 };
 
 /// A marker trait denoting that the given scheme is semi-honest secure.

--- a/scuttlebutt/src/lib.rs
+++ b/scuttlebutt/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::{
     rand_aes::AesRng,
 };
 
-#[cfg(feature = "unix")]
+#[cfg(unix)]
 pub use crate::{
     channel::{
         UnixChannel,


### PR DESCRIPTION
Added flags such that scuttlebutt::channel::UnixChannel and associated types are only built on unix - currently this doesn't build on Windows.

Added more feature flags to popsicle and made openssl dependency optional - it is only used in psty and is therefore not depended upon when not using the psty feature.