### PR TITLE
Fix cargo git dependency format in fancy-garbling/README.md

### DIFF
--- a/fancy-garbling/README.md
+++ b/fancy-garbling/README.md
@@ -68,7 +68,7 @@ To use `fancy-garbling` in your project, add the following line to the
 `[dependencies]` entry in `Cargo.toml`:
 
 ```
-fancy_garbling = { git = "https://github.com/GaloisInc/swanky/fancy-garbling" }
+fancy-garbling = { git = "https://github.com/GaloisInc/swanky" }
 ```
 
 # License


### PR DESCRIPTION
First off, thank you for making this project available. It looks fantastic.

I encountered some difficulties adding `fancy-garbling` as a dependency. I followed the instructions in `fancy-garbling/README.md`, but I got a 404 error. I checked out the cargo documentation for [adding git repositories as dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-dependencies-from-git-repositories) and it looks like cargo is smart enough to find the `Cargo.toml` file that matches the name of the package that you're trying to add even if it's not in the root of the repo. I updated the README to match the format that worked for me. (Even though `Cargo.toml` now has a hyphen in the package name, I was still able to access it import it with the name `fancy_garbling`.) 