### PR TITLE
Delta ot

### DIFF
--- a/ocelot/src/ot/alsz.rs
+++ b/ocelot/src/ot/alsz.rs
@@ -12,24 +12,14 @@
 use crate::{
     errors::Error,
     ot::{
-        CorrelatedReceiver,
-        CorrelatedSender,
-        RandomReceiver,
-        RandomSender,
-        Receiver as OtReceiver,
-        Sender as OtSender,
+        CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
+        Sender as OtSender, FixedKeyInitializer
     },
     utils,
 };
 use rand::{CryptoRng, Rng, RngCore, SeedableRng};
 use scuttlebutt::{
-    utils as scutils,
-    AbstractChannel,
-    AesHash,
-    AesRng,
-    Block,
-    SemiHonest,
-    AES_HASH,
+    utils as scutils, AbstractChannel, AesHash, AesRng, Block, SemiHonest, AES_HASH,
 };
 use std::{convert::TryInto, marker::PhantomData};
 
@@ -46,6 +36,29 @@ pub struct Receiver<OT: OtSender<Msg = Block> + SemiHonest> {
     _ot: PhantomData<OT>,
     pub(super) hash: AesHash,
     rngs: Vec<(AesRng, AesRng)>,
+}
+
+impl<OT: OtReceiver<Msg = Block> + SemiHonest> FixedKeyInitializer for Sender<OT> {
+    fn init_fixed_key<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        channel: &mut C,
+        s_: [u8; 16],
+        rng: &mut RNG,
+    ) -> Result<Self, Error> {
+        let mut ot = OT::init(channel, rng)?;
+        let s = utils::u8vec_to_boolvec(&s_);
+        let ks = ot.receive(channel, &s, rng)?;
+        let rngs = ks
+            .into_iter()
+            .map(AesRng::from_seed)
+            .collect::<Vec<AesRng>>();
+        Ok(Self {
+            _ot: PhantomData::<OT>,
+            hash: AES_HASH,
+            s,
+            s_: Block::from(s_),
+            rngs,
+        })
+    }
 }
 
 impl<OT: OtReceiver<Msg = Block> + SemiHonest> Sender<OT> {
@@ -77,22 +90,9 @@ impl<OT: OtReceiver<Msg = Block> + SemiHonest> OtSender for Sender<OT> {
         channel: &mut C,
         rng: &mut RNG,
     ) -> Result<Self, Error> {
-        let mut ot = OT::init(channel, rng)?;
         let mut s_ = [0u8; 16];
         rng.fill_bytes(&mut s_);
-        let s = utils::u8vec_to_boolvec(&s_);
-        let ks = ot.receive(channel, &s, rng)?;
-        let rngs = ks
-            .into_iter()
-            .map(AesRng::from_seed)
-            .collect::<Vec<AesRng>>();
-        Ok(Self {
-            _ot: PhantomData::<OT>,
-            hash: AES_HASH,
-            s,
-            s_: Block::from(s_),
-            rngs,
-        })
+        Sender::<OT>::init_fixed_key(channel, s_, rng)
     }
 
     fn send<C: AbstractChannel, RNG: CryptoRng + Rng>(

--- a/ocelot/src/ot/alsz.rs
+++ b/ocelot/src/ot/alsz.rs
@@ -12,8 +12,8 @@
 use crate::{
     errors::Error,
     ot::{
-        CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
-        Sender as OtSender, FixedKeyInitializer
+        CorrelatedReceiver, CorrelatedSender, FixedKeyInitializer, RandomReceiver, RandomSender,
+        Receiver as OtReceiver, Sender as OtSender,
     },
     utils,
 };

--- a/ocelot/src/ot/kos.rs
+++ b/ocelot/src/ot/kos.rs
@@ -10,9 +10,10 @@
 use crate::{
     errors::Error,
     ot::{
-        alsz::{Receiver as AlszReceiver, Sender as AlszSender},
         CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
-        Sender as OtSender,
+        Sender as OtSender, FixedKeyInitializer,
+        alsz::{Receiver as AlszReceiver, Sender as AlszSender},
+
     },
     utils,
 };
@@ -27,6 +28,7 @@ const SSP: usize = 40;
 pub struct Sender<OT: OtReceiver<Msg = Block> + Malicious> {
     pub(super) ot: AlszSender<OT>,
 }
+
 /// Oblivious transfer extension receiver.
 pub struct Receiver<OT: OtSender<Msg = Block> + Malicious> {
     ot: AlszReceiver<OT>,
@@ -69,6 +71,17 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {
             )));
         }
         Ok(qs)
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> FixedKeyInitializer for Sender<OT> {
+    fn init_fixed_key<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        channel: &mut C,
+        s_: [u8; 16],
+        rng: &mut RNG,
+    ) -> Result<Self, Error> {
+        let ot = AlszSender::<OT>::init_fixed_key(channel, s_, rng)?;
+        Ok(Self { ot })
     }
 }
 

--- a/ocelot/src/ot/kos.rs
+++ b/ocelot/src/ot/kos.rs
@@ -10,10 +10,9 @@
 use crate::{
     errors::Error,
     ot::{
-        CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
-        Sender as OtSender, FixedKeyInitializer,
         alsz::{Receiver as AlszReceiver, Sender as AlszSender},
-
+        CorrelatedReceiver, CorrelatedSender, FixedKeyInitializer, RandomReceiver, RandomSender,
+        Receiver as OtReceiver, Sender as OtSender,
     },
     utils,
 };

--- a/ocelot/src/ot/kos.rs
+++ b/ocelot/src/ot/kos.rs
@@ -29,15 +29,15 @@ const SSP: usize = 40;
 
 /// Oblivious transfer extension sender.
 pub struct Sender<OT: OtReceiver<Msg = Block> + Malicious> {
-    ot: AlszSender<OT>,
+    pub(super) ot: AlszSender<OT>,
 }
 /// Oblivious transfer extension receiver.
 pub struct Receiver<OT: OtSender<Msg = Block> + Malicious> {
-    ot: AlszReceiver<OT>,
+    pub(super) ot: AlszReceiver<OT>,
 }
 
 impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {
-    fn send_setup<C: AbstractChannel, RNG: CryptoRng + Rng>(
+    pub(super) fn send_setup<C: AbstractChannel, RNG: CryptoRng + Rng>(
         &mut self,
         channel: &mut C,
         m: usize,
@@ -166,7 +166,7 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> std::fmt::Display for Sender<OT> {
 }
 
 impl<OT: OtSender<Msg = Block> + Malicious> Receiver<OT> {
-    fn receive_setup<C: AbstractChannel, RNG: CryptoRng + Rng>(
+    pub(super) fn receive_setup<C: AbstractChannel, RNG: CryptoRng + Rng>(
         &mut self,
         channel: &mut C,
         inputs: &[bool],

--- a/ocelot/src/ot/kos.rs
+++ b/ocelot/src/ot/kos.rs
@@ -11,11 +11,7 @@ use crate::{
     errors::Error,
     ot::{
         alsz::{Receiver as AlszReceiver, Sender as AlszSender},
-        CorrelatedReceiver,
-        CorrelatedSender,
-        RandomReceiver,
-        RandomSender,
-        Receiver as OtReceiver,
+        CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
         Sender as OtSender,
     },
     utils,
@@ -33,7 +29,7 @@ pub struct Sender<OT: OtReceiver<Msg = Block> + Malicious> {
 }
 /// Oblivious transfer extension receiver.
 pub struct Receiver<OT: OtSender<Msg = Block> + Malicious> {
-    pub(super) ot: AlszReceiver<OT>,
+    ot: AlszReceiver<OT>,
 }
 
 impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {

--- a/ocelot/src/ot/kos_delta.rs
+++ b/ocelot/src/ot/kos_delta.rs
@@ -11,8 +11,8 @@ use crate::{
     errors::Error,
     ot::{
         kos::{Receiver as KosReceiver, Sender as KosSender},
-        CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
-        Sender as OtSender, FixedKeyInitializer
+        CorrelatedReceiver, CorrelatedSender, FixedKeyInitializer, RandomReceiver, RandomSender,
+        Receiver as OtReceiver, Sender as OtSender,
     },
 };
 use rand::{CryptoRng, Rng};

--- a/ocelot/src/ot/kos_delta.rs
+++ b/ocelot/src/ot/kos_delta.rs
@@ -14,14 +14,10 @@ use crate::{
         CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
         Sender as OtSender,
     },
-    utils,
 };
-use rand::{CryptoRng, Rng, RngCore, SeedableRng};
-use scuttlebutt::{cointoss, AbstractChannel, AesRng, Block, Malicious, SemiHonest};
-use std::{convert::TryInto, io::ErrorKind};
-
-// The statistical security parameter.
-const SSP: usize = 40;
+use rand::{CryptoRng, Rng};
+use scuttlebutt::{AbstractChannel, Block, Malicious, SemiHonest};
+use std::convert::TryInto;
 
 /// Oblivious transfer extension sender.
 pub struct Sender<OT: OtReceiver<Msg = Block> + Malicious> {

--- a/ocelot/src/ot/kos_delta.rs
+++ b/ocelot/src/ot/kos_delta.rs
@@ -1,0 +1,291 @@
+// -*- mode: rust; -*-
+//
+// This file is part of ocelot.
+// Copyright © 2019 Galois, Inc.
+// See LICENSE for licensing information.
+
+//! Implementation of the Keller-Orsini-Scholl oblivious transfer extension
+//! protocol (cf. <https://eprint.iacr.org/2015/546>).
+
+use crate::{
+    errors::Error,
+    ot::{
+        alsz::{Receiver as AlszReceiver, Sender as AlszSender},
+        CorrelatedReceiver,
+        CorrelatedSender,
+        RandomReceiver,
+        RandomSender,
+        Receiver as OtReceiver,
+        Sender as OtSender,
+    },
+    utils,
+};
+use rand::{CryptoRng, Rng, RngCore, SeedableRng};
+use scuttlebutt::{cointoss, AbstractChannel, AesRng, Block, Malicious, SemiHonest};
+use std::{convert::TryInto, io::ErrorKind};
+
+// The statistical security parameter.
+const SSP: usize = 40;
+
+/// Oblivious transfer extension sender.
+pub struct Sender<OT: OtReceiver<Msg = Block> + Malicious> {
+    ot: AlszSender<OT>,
+}
+/// Oblivious transfer extension receiver.
+pub struct Receiver<OT: OtSender<Msg = Block> + Malicious> {
+    ot: AlszReceiver<OT>,
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {
+    fn send_setup<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        m: usize,
+        rng: &mut RNG,
+    ) -> Result<Vec<u8>, Error> {
+        let m = if m % 8 != 0 { m + (8 - m % 8) } else { m };
+        let ncols = m + 128 + SSP;
+        let qs = self.ot.send_setup(channel, ncols)?;
+        // Check correlation
+        let mut seed = Block::default();
+        rng.fill_bytes(&mut seed.as_mut());
+        let seed = cointoss::send(channel, &[seed])?;
+        let mut rng = AesRng::from_seed(seed[0]);
+        let mut check = (Block::default(), Block::default());
+        let mut chi = Block::default();
+        for j in 0..ncols {
+            let q = &qs[j * 16..(j + 1) * 16];
+            let q: [u8; 16] = q.try_into().unwrap();
+            let q = Block::from(q);
+            rng.fill_bytes(&mut chi.as_mut());
+            let tmp = q.clmul(chi);
+            check = utils::xor_two_blocks(&check, &tmp);
+        }
+        let x = channel.read_block()?;
+        let t0 = channel.read_block()?;
+        let t1 = channel.read_block()?;
+        let tmp = x.clmul(self.ot.s_);
+        let check = utils::xor_two_blocks(&check, &tmp);
+        if check != (t0, t1) {
+            return Err(Error::from(std::io::Error::new(
+                ErrorKind::InvalidData,
+                "Consistency check failed",
+            )));
+        }
+        Ok(qs)
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> OtSender for Sender<OT> {
+    type Msg = Block;
+
+    fn init<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        channel: &mut C,
+        rng: &mut RNG,
+    ) -> Result<Self, Error> {
+        let ot = AlszSender::<OT>::init(channel, rng)?;
+        Ok(Self { ot })
+    }
+
+    fn send<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        inputs: &[(Block, Block)],
+        rng: &mut RNG,
+    ) -> Result<(), Error> {
+        let m = inputs.len();
+        let qs = self.send_setup(channel, m, rng)?;
+        // Output result
+        for (j, input) in inputs.iter().enumerate() {
+            let q = &qs[j * 16..(j + 1) * 16];
+            let q: [u8; 16] = q.try_into().unwrap();
+            let q = Block::from(q);
+            let y0 = self.ot.hash.tccr_hash(Block::from(j as u128), q) ^ input.0;
+            let q = q ^ self.ot.s_;
+            let y1 = self.ot.hash.tccr_hash(Block::from(j as u128), q) ^ input.1;
+            channel.write_block(&y0)?;
+            channel.write_block(&y1)?;
+        }
+        channel.flush()?;
+        Ok(())
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> CorrelatedSender for Sender<OT> {
+    fn send_correlated<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        deltas: &[Self::Msg],
+        rng: &mut RNG,
+    ) -> Result<Vec<(Self::Msg, Self::Msg)>, Error> {
+        let m = deltas.len();
+        let qs = self.send_setup(channel, m, rng)?;
+        let mut out = Vec::with_capacity(m);
+        for (j, delta) in deltas.iter().enumerate() {
+            let q = &qs[j * 16..(j + 1) * 16];
+            let q: [u8; 16] = q.try_into().unwrap();
+            let q = Block::from(q);
+            let x0 = self.ot.hash.tccr_hash(Block::from(j as u128), q);
+            let x1 = x0 ^ *delta;
+            let q = q ^ self.ot.s_;
+            let y = self.ot.hash.tccr_hash(Block::from(j as u128), q) ^ x1;
+            channel.write_block(&y)?;
+            out.push((x0, x1));
+        }
+        channel.flush()?;
+        Ok(out)
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> RandomSender for Sender<OT> {
+    fn send_random<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        m: usize,
+        rng: &mut RNG,
+    ) -> Result<Vec<(Self::Msg, Self::Msg)>, Error> {
+        let qs = self.send_setup(channel, m, rng)?;
+        let mut out = Vec::with_capacity(m);
+        for j in 0..m {
+            let q = &qs[j * 16..(j + 1) * 16];
+            let q: [u8; 16] = q.try_into().unwrap();
+            let q = Block::from(q);
+            out.push((q, q ^ self.ot.s_));
+        }
+        Ok(out)
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> std::fmt::Display for Sender<OT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "KOS Sender")
+    }
+}
+
+impl<OT: OtSender<Msg = Block> + Malicious> Receiver<OT> {
+    fn receive_setup<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        inputs: &[bool],
+        rng: &mut RNG,
+    ) -> Result<Vec<u8>, Error> {
+        let m = inputs.len();
+        let m = if m % 8 != 0 { m + (8 - m % 8) } else { m };
+        let m_ = m + 128 + SSP;
+        let mut r = utils::boolvec_to_u8vec(inputs);
+        r.extend((0..(m_ - m) / 8).map(|_| rand::random::<u8>()));
+        let ts = self.ot.receive_setup(channel, &r, m_)?;
+        // Check correlation
+        let mut seed = Block::default();
+        rng.fill_bytes(&mut seed.as_mut());
+        let seed = cointoss::receive(channel, &[seed])?;
+        let mut rng = AesRng::from_seed(seed[0]);
+        let mut x = Block::default();
+        let mut t = (Block::default(), Block::default());
+        let r_ = utils::u8vec_to_boolvec(&r);
+        let mut chi = Block::default();
+        for (j, xj) in r_.into_iter().enumerate() {
+            let tj = &ts[j * 16..(j + 1) * 16];
+            let tj: [u8; 16] = tj.try_into().unwrap();
+            let tj = Block::from(tj);
+            rng.fill_bytes(&mut chi.as_mut());
+            x ^= if xj { chi } else { Block::default() };
+            let tmp = tj.clmul(chi);
+            t = utils::xor_two_blocks(&t, &tmp);
+        }
+        channel.write_block(&x)?;
+        channel.write_block(&t.0)?;
+        channel.write_block(&t.1)?;
+        channel.flush()?;
+        Ok(ts)
+    }
+}
+
+impl<OT: OtSender<Msg = Block> + Malicious> OtReceiver for Receiver<OT> {
+    type Msg = Block;
+
+    fn init<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        channel: &mut C,
+        rng: &mut RNG,
+    ) -> Result<Self, Error> {
+        let ot = AlszReceiver::<OT>::init(channel, rng)?;
+        Ok(Self { ot })
+    }
+
+    fn receive<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        inputs: &[bool],
+        rng: &mut RNG,
+    ) -> Result<Vec<Block>, Error> {
+        let ts = self.receive_setup(channel, inputs, rng)?;
+        // Output result
+        let mut out = Vec::with_capacity(inputs.len());
+        for (j, b) in inputs.iter().enumerate() {
+            let t = &ts[j * 16..(j + 1) * 16];
+            let t: [u8; 16] = t.try_into().unwrap();
+            let y0 = channel.read_block()?;
+            let y1 = channel.read_block()?;
+            let y = if *b { y1 } else { y0 };
+            let y = y ^ self
+                .ot
+                .hash
+                .tccr_hash(Block::from(j as u128), Block::from(t));
+            out.push(y);
+        }
+        Ok(out)
+    }
+}
+
+impl<OT: OtSender<Msg = Block> + Malicious> CorrelatedReceiver for Receiver<OT> {
+    fn receive_correlated<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        inputs: &[bool],
+        rng: &mut RNG,
+    ) -> Result<Vec<Self::Msg>, Error> {
+        let ts = self.receive_setup(channel, inputs, rng)?;
+        let mut out = Vec::with_capacity(inputs.len());
+        for (j, b) in inputs.iter().enumerate() {
+            let t = &ts[j * 16..(j + 1) * 16];
+            let t: [u8; 16] = t.try_into().unwrap();
+            let y = channel.read_block()?;
+            let y = if *b { y } else { Block::default() };
+            let h = self
+                .ot
+                .hash
+                .tccr_hash(Block::from(j as u128), Block::from(t));
+            out.push(y ^ h);
+        }
+        Ok(out)
+    }
+}
+
+impl<OT: OtSender<Msg = Block> + Malicious> RandomReceiver for Receiver<OT> {
+    fn receive_random<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        &mut self,
+        channel: &mut C,
+        inputs: &[bool],
+        rng: &mut RNG,
+    ) -> Result<Vec<Self::Msg>, Error> {
+        let ts = self.receive_setup(channel, inputs, rng)?;
+        let mut out = Vec::with_capacity(inputs.len());
+        for j in 0..inputs.len() {
+            let t = &ts[j * 16..(j + 1) * 16];
+            let t: [u8; 16] = t.try_into().unwrap();
+            out.push(Block::from(t));
+        }
+        Ok(out)
+    }
+}
+
+impl<OT: OtSender<Msg = Block> + Malicious> std::fmt::Display for Receiver<OT> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "KOS Receiver")
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> SemiHonest for Sender<OT> {}
+impl<OT: OtSender<Msg = Block> + Malicious> SemiHonest for Receiver<OT> {}
+impl<OT: OtReceiver<Msg = Block> + Malicious> Malicious for Sender<OT> {}
+impl<OT: OtSender<Msg = Block> + Malicious> Malicious for Receiver<OT> {}

--- a/ocelot/src/ot/kos_delta.rs
+++ b/ocelot/src/ot/kos_delta.rs
@@ -12,7 +12,7 @@ use crate::{
     ot::{
         kos::{Receiver as KosReceiver, Sender as KosSender},
         CorrelatedReceiver, CorrelatedSender, RandomReceiver, RandomSender, Receiver as OtReceiver,
-        Sender as OtSender,
+        Sender as OtSender, FixedKeyInitializer
     },
 };
 use rand::{CryptoRng, Rng};
@@ -36,6 +36,17 @@ impl<OT: OtReceiver<Msg = Block> + Malicious> Sender<OT> {
         rng: &mut RNG,
     ) -> Result<Vec<u8>, Error> {
         self.ot.send_setup(channel, m, rng)
+    }
+}
+
+impl<OT: OtReceiver<Msg = Block> + Malicious> FixedKeyInitializer for Sender<OT> {
+    fn init_fixed_key<C: AbstractChannel, RNG: CryptoRng + Rng>(
+        channel: &mut C,
+        s_: [u8; 16],
+        rng: &mut RNG,
+    ) -> Result<Self, Error> {
+        let ot = KosSender::init_fixed_key(channel, s_, rng)?;
+        Ok(Self { ot })
     }
 }
 

--- a/ocelot/src/ot/mod.rs
+++ b/ocelot/src/ot/mod.rs
@@ -75,6 +75,7 @@ where
     ) -> Result<(), Error>;
 }
 
+/// Trait for initializing an oblivious transfer object with a fixed key.
 pub trait FixedKeyInitializer
 where
     Self: Sized,

--- a/ocelot/src/ot/mod.rs
+++ b/ocelot/src/ot/mod.rs
@@ -20,6 +20,7 @@ pub mod alsz;
 pub mod chou_orlandi;
 pub mod dummy;
 pub mod kos;
+pub mod kos_delta;
 pub mod naor_pinkas;
 
 use crate::errors::Error;
@@ -46,6 +47,10 @@ pub type AlszReceiver = alsz::Receiver<ChouOrlandiSender>;
 pub type KosSender = kos::Sender<ChouOrlandiReceiver>;
 /// Instantiation of the KOS OT extension receiver, using Chou-Orlandi as the base OT.
 pub type KosReceiver = kos::Receiver<ChouOrlandiSender>;
+/// Instantiation of the KOS Delta-OT extension sender, using Chou-Orlandi as the base OT.
+pub type KosDeltaSender = kos_delta::Sender<ChouOrlandiReceiver>;
+/// Instantiation of the KOS Delta-OT extension receiver, using Chou-Orlandi as the base OT.
+pub type KosDeltaReceiver = kos_delta::Receiver<ChouOrlandiSender>;
 
 /// Trait for one-out-of-two oblivious transfer from the sender's point-of-view.
 pub trait Sender
@@ -347,5 +352,17 @@ mod tests {
         test_otext::<KosSender, KosReceiver>(ninputs);
         test_cotext::<KosSender, KosReceiver>(ninputs);
         test_rotext::<KosSender, KosReceiver>(ninputs);
+    }
+
+    #[test]
+    fn test_kos_delta() {
+        let ninputs = 1 << 10;
+        test_otext::<KosDeltaSender, KosDeltaReceiver>(ninputs);
+        test_cotext::<KosDeltaSender, KosDeltaReceiver>(ninputs);
+        test_rotext::<KosDeltaSender, KosDeltaReceiver>(ninputs);
+        let ninputs = (1 << 10) + 1;
+        test_otext::<KosDeltaSender, KosDeltaReceiver>(ninputs);
+        test_cotext::<KosDeltaSender, KosDeltaReceiver>(ninputs);
+        test_rotext::<KosDeltaSender, KosDeltaReceiver>(ninputs);
     }
 }


### PR DESCRIPTION
We are using swanky for a project, but we need an OT implementation with the same correlation across multiple OTs, aka Delta-OT.
 
In this pull request I've made an extension to `kos.rs` named `kos_delta.rs` which sends `q` and `q ^ s_` instead of the hashed versions. Furthermore `alsz.rs` has been modified to include a fixed key in the initialization of the OT.

I don't know if this is the way to do it and would love to hear your opinion.