### PR TITLE
Naor-Pinkas -- use single random value for sender

### DIFF
--- a/ocelot/src/ot/naor_pinkas.rs
+++ b/ocelot/src/ot/naor_pinkas.rs
@@ -15,9 +15,7 @@ use crate::{
     ot::{Receiver as OtReceiver, Sender as OtSender},
 };
 use curve25519_dalek::{
-    constants::RISTRETTO_BASEPOINT_TABLE,
-    ristretto::RistrettoPoint,
-    scalar::Scalar,
+    constants::RISTRETTO_BASEPOINT_TABLE, ristretto::RistrettoPoint, scalar::Scalar,
 };
 use rand::{CryptoRng, Rng};
 use scuttlebutt::{AbstractChannel, Block, SemiHonest};
@@ -57,17 +55,14 @@ impl OtSender for Sender {
             pks.push((pk0, c - pk0));
         }
         for (i, (input, pk)) in inputs.iter().zip(pks.into_iter()).enumerate() {
-            let r0 = Scalar::random(&mut rng);
-            let r1 = Scalar::random(&mut rng);
-            let e00 = &r0 * &RISTRETTO_BASEPOINT_TABLE;
-            let e10 = &r1 * &RISTRETTO_BASEPOINT_TABLE;
-            let h = Block::hash_pt(i as u128, &(pk.0 * r0));
+            let r = Scalar::random(&mut rng);
+            let ei0 = &r * &RISTRETTO_BASEPOINT_TABLE;
+            let h = Block::hash_pt(i as u128, &(pk.0 * r));
             let e01 = h ^ input.0;
-            let h = Block::hash_pt(i as u128, &(pk.1 * r1));
+            let h = Block::hash_pt(i as u128, &(pk.1 * r));
             let e11 = h ^ input.1;
-            channel.write_pt(&e00)?;
+            channel.write_pt(&ei0)?;
             channel.write_block(&e01)?;
-            channel.write_pt(&e10)?;
             channel.write_block(&e11)?;
         }
         channel.flush()?;
@@ -120,15 +115,14 @@ impl OtReceiver for Receiver {
             .zip(ks.into_iter())
             .enumerate()
             .map(|(i, (b, k))| {
-                let e00 = channel.read_pt()?;
+                let ei0 = channel.read_pt()?;
                 let e01 = channel.read_block()?;
-                let e10 = channel.read_pt()?;
                 let e11 = channel.read_block()?;
-                let (e0, e1) = match b {
-                    false => (e00, e01),
-                    true => (e10, e11),
+                let e1 = match b {
+                    false => e01,
+                    true => e11,
                 };
-                let h = Block::hash_pt(i as u128, &(e0 * k));
+                let h = Block::hash_pt(i as u128, &(ei0 * k));
                 Ok(h ^ e1)
             })
             .collect()


### PR DESCRIPTION
~~The current algorithm seems closer to Bellare-Micali to me, except that nonces are being added to the hashes.~~ In [Naor-Pinkas 2001], they claim that the nonce is only necessary for preventing a malicious public key from being chosen by the receiver (creating a hash collision).

Since the implementation is already including a nonce, the use of two random values `r0`, `r1` is unnecessary. Right? We can use the approach of the adapted protocol in [Naor-Pinkas 2001] with a single random value `r`.

<img width="504" alt="Screen Shot 2022-02-10 at 2 29 25 PM" src="https://user-images.githubusercontent.com/3700330/153482399-91350566-752a-4b0d-8d6f-ecc306b5dbf3.png">

I'm not super familiar with ECC, so if this is unsafe in that setting then please forgive me. Thoughts?