### PR TITLE
feat: Half the number of AND gates for the mux circuit in fancy-garbling

### DIFF
--- a/fancy-garbling/src/fancy.rs
+++ b/fancy-garbling/src/fancy.rs
@@ -124,10 +124,9 @@ pub trait FancyBinary: Fancy {
         x: &Self::Item,
         y: &Self::Item,
     ) -> Result<Self::Item, Self::Error> {
-        let notb = self.negate(b)?;
-        let xsel = self.and(&notb, x)?;
-        let ysel = self.and(b, y)?;
-        self.xor(&xsel, &ysel)
+        let xor = self.xor(x, y)?;
+        let and = self.and(b, &xor)?;
+        self.xor(&and, x)
     }
 }
 


### PR DESCRIPTION
The MUX gate is currently implemented as:
  (NOT b AND x) XOR (b AND y)
This requires two AND gates (+1 XOR + 1 NOT) to compute.

The same circuit, however, can be achieved with just one AND gate (+ 2 XOR):
  (b AND (x XOR y)) XOR x
