### PR TITLE
Build for wasm32-unknown-unknown (twopac, chou-orlandi, alsz-kos)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,8 @@
-[build]
-rustflags = [
-    "-C", "target-cpu=native", "--cfg", "vectoreyes_target_cpu_native", "-C", "link-args=-flto"
-]
 # Pass --html-in-header flags to rustdoc. See the script for details.
 rustdoc = "./etc/rustdoc-wrapper.sh"
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "target-cpu=native", "--cfg", "vectoreyes_target_cpu_native", "-C", "link-args=-flto"]
+
+[target.wasm32-unknown-unknown]
+rustflags = []

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,8 +979,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2859,6 +2861,7 @@ dependencies = [
  "blake3",
  "bytemuck",
  "criterion",
+ "getrandom 0.2.17",
  "keyed_arena",
  "rand 0.8.5",
  "swanky-adversary",
@@ -2884,6 +2887,7 @@ dependencies = [
  "blake3",
  "criterion",
  "curve25519-dalek",
+ "getrandom 0.2.17",
  "rand 0.8.5",
  "swanky-adversary",
  "swanky-block",
@@ -3040,6 +3044,7 @@ dependencies = [
  "clap",
  "criterion",
  "fancy-garbling",
+ "getrandom 0.2.17",
  "itertools 0.14.0",
  "rand 0.8.5",
  "swanky-adversary",

--- a/edge/ot-alsz-kos/Cargo.toml
+++ b/edge/ot-alsz-kos/Cargo.toml
@@ -29,6 +29,9 @@ vectoreyes.workspace = true
 blake3.workspace = true
 bytemuck.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 swanky-ot-test.workspace = true
 criterion.workspace = true

--- a/edge/ot-chou-orlandi/Cargo.toml
+++ b/edge/ot-chou-orlandi/Cargo.toml
@@ -20,6 +20,9 @@ swanky-ocelot-error.workspace = true
 swanky-ot-traits.workspace = true
 blake3.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 swanky-ot-test.workspace = true
 criterion.workspace = true

--- a/edge/twopac/Cargo.toml
+++ b/edge/twopac/Cargo.toml
@@ -23,6 +23,9 @@ swanky-ot-traits.workspace = true
 itertools.workspace = true
 rand.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
+
 [dev-dependencies]
 swanky-ot-chou-orlandi.workspace = true
 swanky-ot-alsz-kos.workspace = true


### PR DESCRIPTION
## What

Two minimal Cargo plumbing changes that let `swanky-twopac` and the two OT crates it depends on (`swanky-ot-chou-orlandi`, `swanky-ot-alsz-kos`) build cleanly for `wasm32-unknown-unknown`.

```
 .cargo/config.toml              | 10 ++++++----
 Cargo.lock                      |  5 +++++
 edge/ot-alsz-kos/Cargo.toml     |  3 +++
 edge/ot-chou-orlandi/Cargo.toml |  3 +++
 edge/twopac/Cargo.toml          |  3 +++
 5 files changed, 20 insertions(+), 4 deletions(-)
```

1. **`.cargo/config.toml`** — split the workspace-wide `-C target-cpu=native` rustflag out from the global `[build]` into per-target sections. `target-cpu=native` is meaningless on `wasm32` and rustc refuses to compile when it sees it for that target. Native builds keep `target-cpu=native` exactly as before (now via `[target.aarch64-apple-darwin]` / `[target.x86_64-*]` instead of the global `[build]`).

2. **Three crate `Cargo.toml`s** — enable the `js` feature on `getrandom = "0.2"` under `[target.'cfg(target_arch="wasm32")'.dependencies]`. Without this `getrandom` errors at compile time on wasm32 with the well-known "the wasm*-unknown-unknown targets are not supported by default" message.

## What this unlocks

The `swanky-twopac::semihonest::Garbler` / `Evaluator` path now compiles + links into a browser-shipped `.wasm` artifact. The two-party MPC built on `fancy-garbling` + `swanky-ot-alsz-kos` runs end-to-end between a wasm garbler in a Web Worker and a native swanky evaluator over a TCP/WebSocket transport. We've verified this on our side with a real `bin_addition_no_carry` protocol round-trip and a permutation-lookup garbled circuit. Post wasm-bindgen artifact size: ~195 KB.

## What this doesn't change

- No source files touched.
- No new dependencies.
- Native targets keep `target-cpu=native` exactly as before.
- `vectoreyes`'s scalar fallback already covers wasm32 — no SIMD patch needed.
- `scuttlebutt`/`channel-legacy`'s `UnixStream`/`std::thread` uses are already `#[cfg(unix)]` or in `#[test]` blocks.
- `curve25519-dalek`, `blake3`, `sha2`, `aes` all build clean for wasm32 unchanged.

## How to verify

```bash
rustup target add wasm32-unknown-unknown
cargo build --target wasm32-unknown-unknown \
  -p swanky-twopac -p swanky-ot-chou-orlandi -p swanky-ot-alsz-kos
```

(This PR targets individual crates only; some workspace members still have other native-only blockers — e.g. crates that link C deps — which this PR doesn't address.)

## Why

We (oxiatech) ship an open-source encrypted-inference gateway where the user's MPC garbler half needs to run in a browser tab. swanky's semi-honest 2PC stack is the cleanest match for that protocol; with this patch we can use it unmodified. Happy to split into two commits if preferred — one for the config split, one for the `getrandom` feature gates.